### PR TITLE
Fixing npm install issues

### DIFF
--- a/templates/git/content/package.json
+++ b/templates/git/content/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "{{project}}",
-  , "version": "0.0.1",
-  , "description": "{{description}}",
-  , "keywords": [],
-  , "author": "{{name}} <{{email}}>",
+    "name": "{{project}}"
+  , "version": "0.0.1"
+  , "description": "{{description}}"
+  , "keywords": []
+  , "author": "{{name}} <{{email}}>"
   , "dependencies": {}
   , "main": "index"
   , "engines": { "node": "0.4.x" }


### PR DESCRIPTION
Removing extra commas from templates/git/content/package.json. npm parses all package.json files and fails  after finding double commas on the git template package.

This patch fixes issue #10
